### PR TITLE
Make `item` an array to comply with new, stricter validation

### DIFF
--- a/app/controllers/weather_controller.rb
+++ b/app/controllers/weather_controller.rb
@@ -10,7 +10,7 @@ class WeatherController < ApplicationController
 		@raw_weather_data = open("http://weather.yahooapis.com/forecastrss?w=#{params[:id]}&u=#{params[:unit]}").read
 		@wd = XmlSimple.xml_in(@raw_weather_data, { 'ForceArray' => false })['channel']['item']['condition']
 		#{"item":{"text":"<div class='t-size-x72'>-6&deg;</div><div>Cloudy</div>"}}
-		@weather_text = {'item' => {'text' => "<div class='t-size-x72'>#{@wd['temp']}&deg;</div><div>#{@wd['text']}</div>"}}
+		@weather_text = {'item' => [{'text' => "<div class='t-size-x72'>#{@wd['temp']}&deg;</div><div>#{@wd['text']}</div>"}]}
 		respond_with @weather_text
 	end
 	


### PR DESCRIPTION
Hi Dave,

I'm Ben, a Product Manager at Geckoboard. We've recently made some updates to how we validate widget payloads so that the logic is stricter. As a result of this, customers of ours who are using your app to provide weather info have been experiencing broken widgets. The reason is that the Text widget expects an array of pages, even if there's only 1 page: https://developer.geckoboard.com/#text

I've made the required change in this PR, and would be very grateful if you could merge it and re-deploy the app. Please don't hesitate to get in contact if you have any questions.

All the best,
Ben
