### PR TITLE
Use different, working yahoo weather api endpoint.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,35 +1,13 @@
 source 'http://rubygems.org'
 
 gem 'rails', '3.0.5'
-
-# Bundle edge Rails instead:
-# gem 'rails', :git => 'git://github.com/rails/rails.git'
-
-gem 'sqlite3'
+gem 'pg'
+gem 'puma'
 
 gem 'xml-simple'
 
 gem 'flickraw'
 
-# Use unicorn as the web server
-# gem 'unicorn'
-
-# Deploy with Capistrano
-# gem 'capistrano'
-
-# To use debugger (ruby-debug for Ruby 1.8.7+, ruby-debug19 for Ruby 1.9.2+)
-# gem 'ruby-debug'
-# gem 'ruby-debug19', :require => 'ruby-debug'
-
-# Bundle the extra gems:
-# gem 'bj'
-# gem 'nokogiri'
-# gem 'sqlite3-ruby', :require => 'sqlite3'
-# gem 'aws-s3', :require => 'aws/s3'
-
-# Bundle gems for the local environment. Make sure to
-# put test-only gems in this group so their generators
-# and rake tasks are available in development mode:
-# group :development, :test do
-#   gem 'webrat'
-# end
+group :production do
+  gem 'rails_12factor'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,9 @@ GEM
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
     mime-types (1.25.1)
+    pg (0.18.4)
     polyglot (0.3.5)
+    puma (3.4.0)
     rack (1.2.8)
     rack-mount (0.6.14)
       rack (>= 1.0.0)
@@ -54,13 +56,17 @@ GEM
       activesupport (= 3.0.5)
       bundler (~> 1.0)
       railties (= 3.0.5)
+    rails_12factor (0.0.3)
+      rails_serve_static_assets
+      rails_stdout_logging
+    rails_serve_static_assets (0.0.5)
+    rails_stdout_logging (0.0.5)
     railties (3.0.5)
       actionpack (= 3.0.5)
       activesupport (= 3.0.5)
       rake (>= 0.8.7)
       thor (~> 0.14.4)
     rake (11.1.2)
-    sqlite3 (1.3.11)
     thor (0.14.6)
     treetop (1.4.15)
       polyglot
@@ -73,8 +79,10 @@ PLATFORMS
 
 DEPENDENCIES
   flickraw
+  pg
+  puma
   rails (= 3.0.5)
-  sqlite3
+  rails_12factor
   xml-simple
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,21 +28,21 @@ GEM
       activemodel (= 3.0.5)
       activesupport (= 3.0.5)
     activesupport (3.0.5)
-    arel (2.0.9)
+    arel (2.0.10)
     builder (2.1.2)
     erubis (2.6.6)
       abstract (>= 1.0.0)
-    flickraw (0.9.5)
-    i18n (0.5.0)
-    mail (2.2.15)
+    flickraw (0.9.8)
+    i18n (0.7.0)
+    mail (2.2.20)
       activesupport (>= 2.3.6)
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mime-types (1.16)
-    polyglot (0.3.1)
-    rack (1.2.1)
-    rack-mount (0.6.13)
+    mime-types (1.25.1)
+    polyglot (0.3.5)
+    rack (1.2.8)
+    rack-mount (0.6.14)
       rack (>= 1.0.0)
     rack-test (0.5.7)
       rack (>= 1.0)
@@ -59,19 +59,23 @@ GEM
       activesupport (= 3.0.5)
       rake (>= 0.8.7)
       thor (~> 0.14.4)
-    rake (0.8.7)
-    sqlite3 (1.3.3-x86-mingw32)
+    rake (11.1.2)
+    sqlite3 (1.3.11)
     thor (0.14.6)
-    treetop (1.4.9)
+    treetop (1.4.15)
+      polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.24)
-    xml-simple (1.1.1)
+    tzinfo (0.3.48)
+    xml-simple (1.1.5)
 
 PLATFORMS
-  x86-mingw32
+  ruby
 
 DEPENDENCIES
   flickraw
   rails (= 3.0.5)
   sqlite3
   xml-simple
+
+BUNDLED WITH
+   1.11.0

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec puma -p $PORT

--- a/app/controllers/weather_controller.rb
+++ b/app/controllers/weather_controller.rb
@@ -6,9 +6,9 @@ class WeatherController < ApplicationController
 	respond_to :json
 	
 	def get
-		puts params
-		@raw_weather_data = open("http://weather.yahooapis.com/forecastrss?w=#{params[:id]}&u=#{params[:unit]}").read
-		@wd = XmlSimple.xml_in(@raw_weather_data, { 'ForceArray' => false })['channel']['item']['condition']
+    @raw_weather_data = open("https://query.yahooapis.com/v1/public/yql?q=select%20item.condition%20from%20weather.forecast%20where%20woeid%20%3D%20#{params[:id]}%20and%20u%20%3d%20'#{params[:unit]}'&format=json&env=store%3A%2F%2Fdatatables.org%2Falltableswithkeys").read
+    json = JSON.parse(@raw_weather_data)
+    @wd = json['query']['results']['channel']['item']['condition']
 		#{"item":{"text":"<div class='t-size-x72'>-6&deg;</div><div>Cloudy</div>"}}
 		@weather_text = {'item' => [{'text' => "<div class='t-size-x72'>#{@wd['temp']}&deg;</div><div>#{@wd['text']}</div>"}]}
 		respond_with @weather_text

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,7 +16,11 @@ test:
   timeout: 5000
 
 production:
-  adapter: sqlite3
-  database: db/production.sqlite3
-  pool: 5
-  timeout: 5000
+  adapter:  postgresql
+  host:     localhost
+  encoding: unicode
+  database: weather_production
+  pool:     5
+  username: weather
+  password:
+  template: template0


### PR DESCRIPTION
Hey there! We get a lot of use out of this little webapp. Works great with our geckoboards! Unfortunately it hasn't been working lately. I'm not up to date with Yahoo APIs, so I don't know if the one you were using has been deprecated or what, but the error message returned looked like it required authentication.

Now, you don't have to use this if you don't want to, but I've changed the controller action to request a different yahoo weather api which seems to work without any authentication. I didn't see any tests, and I didn't add any. Looks like there's also issues with tabs vs. spaces and windows vs unix newlines.

Thanks again for creating this in the first place!
